### PR TITLE
Fix breadcrumb's ">" separator

### DIFF
--- a/_banner.scss
+++ b/_banner.scss
@@ -43,7 +43,7 @@
         color: inherit;
 
         &:after {
-          content: '>';
+          content: ' >';
           font-size: 0.7em;
           font-weight: bold;
           position: relative;


### PR DESCRIPTION
If the separator content is just ">", the output will look like "Search> Depression"
unless we add the whitespaces to the "Search" string. Adding the whitespace with
CSS makes it work no matter the contents of the breadcrumb.

I could've added a margin instead, but changing the content was simpler.
